### PR TITLE
EthSecp

### DIFF
--- a/packages/amino/src/encoding.spec.ts
+++ b/packages/amino/src/encoding.spec.ts
@@ -7,6 +7,7 @@ import {
   encodeAminoPubkey,
   encodeBech32Pubkey,
   encodeEd25519Pubkey,
+  encodeEthSecp256k1Pubkey,
   encodeSecp256k1Pubkey,
 } from "./encoding";
 import { Pubkey } from "./pubkeys";
@@ -58,6 +59,25 @@ describe("encoding", () => {
     });
   });
 
+  describe("encodeEthSecp256k1Pubkey", () => {
+    it("encodes a compressed pubkey", () => {
+      const pubkey = fromBase64("Ay+1uNze+glFQM+T05EfzL8fQ1Y/wqO8K7q6tUM3BGin");
+      expect(encodeEthSecp256k1Pubkey(pubkey)).toEqual({
+        type: "tendermint/PubKeyEthSecp256k1",
+        value: "Ay+1uNze+glFQM+T05EfzL8fQ1Y/wqO8K7q6tUM3BGin",
+      });
+    });
+
+    it("throws for uncompressed public keys", () => {
+      const pubkey = fromBase64(
+        "BE8EGB7ro1ORuFhjOnZcSgwYlpe0DSFjVNUIkNNQxwKQE7WHpoHoNswYeoFkuYpYSKK4mzFzMV/dB0DVAy4lnNU=",
+      );
+      expect(() => encodeEthSecp256k1Pubkey(pubkey)).toThrowError(
+        /public key must be compressed ethsecp256k1/i,
+      );
+    });
+  });
+
   describe("decodeAminoPubkey", () => {
     it("works for secp256k1", () => {
       const amino = fromBech32(
@@ -68,6 +88,18 @@ describe("encoding", () => {
         value: "A08EGB7ro1ORuFhjOnZcSgwYlpe0DSFjVNUIkNNQxwKQ",
       });
     });
+
+    // @todo: find a way to bypass the identical prefix for secp256k1 and ethsecp256k1
+    //        in @amino/encoding:decodeAminoPubkey
+    // it("works for ethsecp256k1", () => {
+    //   const amino = fromBech32(
+    //     "evmospub1addwnpepqvhmtwxummaqj32qe7fa8yglejl37s6k8lp280pth2at2sehq352w6wm5v0",
+    //   ).data;
+    //   expect(decodeAminoPubkey(amino)).toEqual({
+    //     type: "tendermint/PubKeyEthSecp256k1",
+    //     value: "Ay+1uNze+glFQM+T05EfzL8fQ1Y/wqO8K7q6tUM3BGin",
+    //   });
+    // });
 
     it("works for ed25519", () => {
       // Encoded from `corald tendermint show-validator`
@@ -143,6 +175,17 @@ describe("encoding", () => {
       });
     });
 
+    // @todo: find a way to bypass the identical prefix for secp256k1 and ethsecp256k1
+    //        in @amino/encoding:decodeAminoPubkey
+    // it("works for ethsecp256k1", () => {
+    //   expect(
+    //     decodeBech32Pubkey("evmospub1addwnpepqvhmtwxummaqj32qe7fa8yglejl37s6k8lp280pth2at2sehq352w6wm5v0"),
+    //   ).toEqual({
+    //     type: "tendermint/PubKeyEthSecp256k1",
+    //     value: "Ay+1uNze+glFQM+T05EfzL8fQ1Y/wqO8K7q6tUM3BGin",
+    //   });
+    // });
+
     it("works for enigma pubkey", () => {
       expect(
         decodeBech32Pubkey("enigmapub1addwnpepqw5k9p439nw0zpg2aundx4umwx4nw233z5prpjqjv5anl5grmnchzp2xwvv"),
@@ -183,6 +226,17 @@ describe("encoding", () => {
       expect(encodeAminoPubkey(pubkey)).toEqual(expected);
     });
 
+    it("works for ethsecp256k1", () => {
+      const pubkey: Pubkey = {
+        type: "tendermint/PubKeyEthSecp256k1",
+        value: "Ay+1uNze+glFQM+T05EfzL8fQ1Y/wqO8K7q6tUM3BGin",
+      };
+      const expected = fromBech32(
+        "evmospub1addwnpepqvhmtwxummaqj32qe7fa8yglejl37s6k8lp280pth2at2sehq352w6wm5v0",
+      ).data;
+      expect(encodeAminoPubkey(pubkey)).toEqual(expected);
+    });
+
     it("works for ed25519", () => {
       // Decoded from http://localhost:26657/validators
       // Encoded from `corald tendermint show-validator`
@@ -205,6 +259,16 @@ describe("encoding", () => {
       };
       expect(encodeBech32Pubkey(pubkey, "cosmospub")).toEqual(
         "cosmospub1addwnpepqd8sgxq7aw348ydctp3n5ajufgxp395hksxjzc6565yfp56scupfqhlgyg5",
+      );
+    });
+
+    it("works for ethsecp256k1", () => {
+      const pubkey: Pubkey = {
+        type: "tendermint/PubKeyEthSecp256k1",
+        value: "Ay+1uNze+glFQM+T05EfzL8fQ1Y/wqO8K7q6tUM3BGin",
+      };
+      expect(encodeBech32Pubkey(pubkey, "evmospub")).toEqual(
+        "evmospub1addwnpepqvhmtwxummaqj32qe7fa8yglejl37s6k8lp280pth2at2sehq352w6wm5v0",
       );
     });
 

--- a/packages/amino/src/index.ts
+++ b/packages/amino/src/index.ts
@@ -11,6 +11,7 @@ export {
   encodeAminoPubkey,
   encodeBech32Pubkey,
   encodeEd25519Pubkey,
+  encodeEthSecp256k1Pubkey,
   encodeSecp256k1Pubkey,
 } from "./encoding";
 export { createMultisigThresholdPubkey } from "./multisig";
@@ -18,7 +19,9 @@ export { omitDefault } from "./omitdefault";
 export { makeCosmoshubPath } from "./paths";
 export {
   Ed25519Pubkey,
+  EthSecp256k1Pubkey,
   isEd25519Pubkey,
+  isEthSecp256k1Pubkey,
   isMultisigThresholdPubkey,
   isSecp256k1Pubkey,
   isSinglePubkey,

--- a/packages/amino/src/pubkeys.ts
+++ b/packages/amino/src/pubkeys.ts
@@ -24,10 +24,20 @@ export function isSecp256k1Pubkey(pubkey: Pubkey): pubkey is Secp256k1Pubkey {
   return (pubkey as Secp256k1Pubkey).type === "tendermint/PubKeySecp256k1";
 }
 
+export interface EthSecp256k1Pubkey extends SinglePubkey {
+  readonly type: "tendermint/PubKeyEthSecp256k1";
+  readonly value: string;
+}
+
+export function isEthSecp256k1Pubkey(pubkey: Pubkey): pubkey is EthSecp256k1Pubkey {
+  return (pubkey as EthSecp256k1Pubkey).type === "tendermint/PubKeyEthSecp256k1";
+}
+
 export const pubkeyType = {
-  /** @see https://github.com/tendermint/tendermint/blob/v0.33.0/crypto/ed25519/ed25519.go#L22 */
-  secp256k1: "tendermint/PubKeySecp256k1" as const,
   /** @see https://github.com/tendermint/tendermint/blob/v0.33.0/crypto/secp256k1/secp256k1.go#L23 */
+  secp256k1: "tendermint/PubKeySecp256k1" as const,
+  ethsecp256k1: "tendermint/PubKeyEthSecp256k1" as const,
+  /** @see https://github.com/tendermint/tendermint/blob/v0.33.0/crypto/ed25519/ed25519.go#L22 */
   ed25519: "tendermint/PubKeyEd25519" as const,
   /** @see https://github.com/tendermint/tendermint/blob/v0.33.0/crypto/sr25519/codec.go#L12 */
   sr25519: "tendermint/PubKeySr25519" as const,

--- a/packages/proto-signing/src/pubkey.ts
+++ b/packages/proto-signing/src/pubkey.ts
@@ -3,6 +3,7 @@ import {
   encodeEd25519Pubkey,
   encodeSecp256k1Pubkey,
   isEd25519Pubkey,
+  isEthSecp256k1Pubkey,
   isMultisigThresholdPubkey,
   isSecp256k1Pubkey,
   MultisigThresholdPubkey,
@@ -39,6 +40,14 @@ export function encodePubkey(pubkey: Pubkey): Any {
       typeUrl: "/cosmos.crypto.ed25519.PubKey",
       value: Uint8Array.from(CosmosCryptoEd25519Pubkey.encode(pubkeyProto).finish()),
     });
+  } else if (isEthSecp256k1Pubkey(pubkey)) {
+    const pubkeyProto = CosmosCryptoSecp256k1Pubkey.fromPartial({
+      key: fromBase64(pubkey.value),
+    });
+    return Any.fromPartial({
+      typeUrl: "/ethermint.crypto.v1.ethsecp256k1.PubKey",
+      value: Uint8Array.from(CosmosCryptoSecp256k1Pubkey.encode(pubkeyProto).finish()),
+    });
   } else if (isMultisigThresholdPubkey(pubkey)) {
     const pubkeyProto = LegacyAminoPubKey.fromPartial({
       threshold: Uint53.fromString(pubkey.value.threshold).toNumber(),
@@ -61,13 +70,14 @@ export function encodePubkey(pubkey: Pubkey): Any {
  */
 export function anyToSinglePubkey(pubkey: Any): SinglePubkey {
   switch (pubkey.typeUrl) {
-    case "/cosmos.crypto.secp256k1.PubKey": {
-      const { key } = CosmosCryptoSecp256k1Pubkey.decode(pubkey.value);
-      return encodeSecp256k1Pubkey(key);
-    }
     case "/cosmos.crypto.ed25519.PubKey": {
       const { key } = CosmosCryptoEd25519Pubkey.decode(pubkey.value);
       return encodeEd25519Pubkey(key);
+    }
+    case "/ethermint.crypto.v1.ethsecp256k1.PubKey":
+    case "/cosmos.crypto.secp256k1.PubKey": {
+      const {key} = CosmosCryptoSecp256k1Pubkey.decode(pubkey.value);
+      return encodeSecp256k1Pubkey(key);
     }
     default:
       throw new Error(`Pubkey type_url ${pubkey.typeUrl} not recognized as single public key type`);
@@ -81,6 +91,7 @@ export function anyToSinglePubkey(pubkey: Any): SinglePubkey {
  */
 export function decodePubkey(pubkey: Any): Pubkey {
   switch (pubkey.typeUrl) {
+    case "/ethermint.crypto.v1.ethsecp256k1.PubKey":
     case "/cosmos.crypto.secp256k1.PubKey":
     case "/cosmos.crypto.ed25519.PubKey": {
       return anyToSinglePubkey(pubkey);

--- a/packages/stargate/src/accounts.ts
+++ b/packages/stargate/src/accounts.ts
@@ -58,6 +58,11 @@ export function accountFromAny(input: Any): Account {
       assert(baseAccount);
       return accountFromBaseAccount(baseAccount);
     }
+    case "/ethermint.types.v1.EthAccount": {
+      const baseAccount = ModuleAccount.decode(value).baseAccount;
+      assert(baseAccount);
+      return accountFromBaseAccount(baseAccount);
+    }
 
     // vesting
 

--- a/packages/stargate/src/signingstargateclient.ts
+++ b/packages/stargate/src/signingstargateclient.ts
@@ -1,4 +1,9 @@
-import { encodeSecp256k1Pubkey, makeSignDoc as makeSignDocAmino, StdFee } from "@cosmjs/amino";
+import {
+  encodeEthSecp256k1Pubkey,
+  encodeSecp256k1Pubkey,
+  makeSignDoc as makeSignDocAmino,
+  StdFee,
+} from "@cosmjs/amino";
 import { fromBase64 } from "@cosmjs/encoding";
 import { Int53, Uint53 } from "@cosmjs/math";
 import {
@@ -398,7 +403,11 @@ export class SigningStargateClient extends StargateClient {
     if (!accountFromSigner) {
       throw new Error("Failed to retrieve account from signer");
     }
-    const pubkey = encodePubkey(encodeSecp256k1Pubkey(accountFromSigner.pubkey));
+    const pubkey = encodePubkey(
+      chainId.startsWith("evmos_9001-")
+        ? encodeEthSecp256k1Pubkey(accountFromSigner.pubkey)
+        : encodeSecp256k1Pubkey(accountFromSigner.pubkey),
+    );
     const signMode = SignMode.SIGN_MODE_LEGACY_AMINO_JSON;
     const msgs = messages.map((msg) => this.aminoTypes.toAmino(msg));
     const signDoc = makeSignDocAmino(msgs, fee, chainId, memo, accountNumber, sequence, timeoutHeight);
@@ -445,7 +454,11 @@ export class SigningStargateClient extends StargateClient {
     if (!accountFromSigner) {
       throw new Error("Failed to retrieve account from signer");
     }
-    const pubkey = encodePubkey(encodeSecp256k1Pubkey(accountFromSigner.pubkey));
+    const pubkey = encodePubkey(
+      chainId.startsWith("evmos_9001-")
+        ? encodeEthSecp256k1Pubkey(accountFromSigner.pubkey)
+        : encodeSecp256k1Pubkey(accountFromSigner.pubkey),
+    );
     const txBodyEncodeObject: TxBodyEncodeObject = {
       typeUrl: "/cosmos.tx.v1beta1.TxBody",
       value: {


### PR DESCRIPTION
add amino tests for EthSecp

decode ethsecp256k1 from bech32 is not possible yet: secp256k1 and ethsecp256k1 has the same prefix

chore: patch pubkey for EthSecp